### PR TITLE
Add github workflow for publishing Ruby gem

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on: workflow_dispatch
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish Gem
+
+on: workflow_dispatch
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: '3.2.4'
+      - uses: rubygems/release-gem@v1


### PR DESCRIPTION
**What does this PR do?**

This PR adds a github workflow that publishes this repo as a Ruby gem.

**Motivation**

This workflow should set up trusted publishing of the gem. It's based on [this repo](https://github.com/rubygems/release-gem) that allows you to automate releasing your gems to RubyGems.org.

**Additional notes:**

This PR is another step (after #2 ) toward the overall project goal of creating and using a new `datadog-ruby_core_source` gem. See [here](https://docs.google.com/document/d/1lbehlvLADt_ztblhlEnnTFKQ8EVxxOWHdgFzTSqD9Qc/edit?tab=t.0#task=YxycgZORWQhz-chI) for more info on the project.