### PR TITLE
Remove unused files upon gem install

### DIFF
--- a/datadog-ruby_core_source.gemspec
+++ b/datadog-ruby_core_source.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "archive-tar-minitar", ">= 0.5.2"
   s.add_development_dependency 'rake', '>= 0.9.2'
   s.add_development_dependency 'minitar-cli'
+  s.extensions = ['ext/shave/extconf.rb']
 end

--- a/ext/shave/extconf.rb
+++ b/ext/shave/extconf.rb
@@ -1,0 +1,16 @@
+require 'mkmf'
+require 'fileutils'
+
+$LOAD_PATH.push(__dir__ + '/../../lib')
+
+require 'datadog/ruby_core_source'
+
+dir = Datadog::RubyCoreSource.deduce_packaged_source_dir("ruby-#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}")
+
+unused = Dir.glob(File.dirname(dir) + '/*') - [dir]
+
+unused.each do |path|
+  FileUtils.rm_rf path
+end
+
+create_makefile 'shave'


### PR DESCRIPTION
Given that:

- `RubyCoreSource.create_makefile_with_core` is the main entry point and computes things from the current runtime information
- `RubyCoreSource.deduce_packaged_source_dir` receives that information

Let's directly make use of that to reduce the gem size post-install ~by adding a scri...~

Wait, not post-install. That's too manual. Let's do it zero-step, _at install time_.

- `extconf.rb` is just a ruby script.
- `spec.extensions = ['path/to/some/script.rb']` is but a callback mechanism to call the above script.
- `ext/foo/extconf.rb` is a mere convention.

Buuuuut it has to have a `Makefile` (also convention because hey, it's named `extension` after all)... so let's add a dummy `MakeMakefile.create_makefile` with an empty, unused stub C file.

Results:

```console
$ bundle exec rake build
datadog-ruby_core_source 3.3.6 built to pkg/datadog-ruby_core_source-3.3.6.gem.

$ env GEM_HOME=tmp/gem_home gem install pkg/datadog-ruby_core_source-3.3.6.gem
Building native extensions. This could take a while...
Successfully installed datadog-ruby_core_source-3.3.6
Parsing documentation for datadog-ruby_core_source-3.3.6
Installing ri documentation for datadog-ruby_core_source-3.3.6
Done installing documentation for datadog-ruby_core_source after 0 seconds
1 gem installed

$ ls tmp/gem_home/gems/datadog-ruby_core_source-3.3.6/lib/datadog/ruby_core_source
ruby-3.3.5-p100

$ du -h -d 0 tmp/gem_home/gems/datadog-ruby_core_source-3.3.6/lib/datadog/ruby_core_source
1.6M	tmp/gem_home/gems/datadog-ruby_core_source-3.3.6/lib/datadog/ruby_core_source
```

Yup. 1.6 MB, down from `master`'s 8-ish MB.

Note: I tried to use `MakeMakefile.dummy_makefile` but it failed so I resorted to the above as a quick hack. Should not be that hard to create a `Makefile` that does nothing instead?