### PR TITLE
[PROF-11035] Fix breaking "publish gem" due to optional development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-group :development, optional: true do
-  gem 'pry'
-end


### PR DESCRIPTION
**What does this PR do?**

This PR removes the optional development group with the `pry` gem. It was added in #8, but it being optional breaks the "publish gem" github flow with:

```
Run bundle exec rake release
bundler: failed to load command: rake (/opt/hostedtoolcache/Ruby/3.2.4/x64/bin/rake)
/opt/hostedtoolcache/Ruby/3.2.4/x64/lib/ruby/3.2.0/bundler/rubygems_integration.rb:308:in `block in replace_bin_path': can't find executable rake for gem rake. rake is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
```

I was able to reproduce the same issue locally, it happens because the development group was marked optional.

Since this has been a bit of a back and forth, for now let's just remove `pry` and we can add it back locally or whatnot if when needed.

**Motivation:**

This is blocking the 3.3.7 release, see
https://github.com/DataDog/datadog-ruby_core_source/actions/runs/12354204200/job/34475175057#step:4:5

**Additional Notes:**

N/A

**How to test the change?**

Without this PR, locally running `bundle exec rake` fails for me with the error above; with this change, I'm able to run `rake` successfully.