### PR TITLE
[NO-TICKET] Bump required Ruby version to 2.5

### DIFF
--- a/datadog-ruby_core_source.gemspec
+++ b/datadog-ruby_core_source.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = %q{Provide Ruby core source files for C extensions that need them.}
   s.license = "MIT"
   s.required_rubygems_version = ">= 1.3.6"
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.extra_rdoc_files = [ "README.md"]
   s.files = `git ls-files`.split("\n")
     .reject { |fn| fn.include?('find_includes.rb') }


### PR DESCRIPTION
**What does this PR do?**

This PR bumps the required ruby version for the gem to Ruby 2.5.0.

**Motivation:**

We're not actively targetting any older release than that (or testing with), so might as well clarify that in our gemspec.

**Additional Notes:**

N/A

**How to test the change?**

Validate CI is still green :)

Validate that the required Ruby version shows up on rubygems.org once we publish the update.