### PR TITLE
[PROF-11809] Allow overriding headers folder using env var

### DIFF
--- a/lib/datadog/ruby_core_source.rb
+++ b/lib/datadog/ruby_core_source.rb
@@ -35,7 +35,7 @@ module Datadog
       end
 
       # Look for sources that ship with gem
-      dest_dir = deduce_packaged_source_dir(ruby_dir)
+      dest_dir = ENV["DATADOG_RUBY_HEADERS_OVERRIDE"] || deduce_packaged_source_dir(ruby_dir)
       $stderr.puts "Using datadog-ruby_core_source headers from #{dest_dir}"
       no_source_abort(ruby_dir) unless File.directory?(dest_dir)
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds the ability to override the folder used for reading the headers from using an environment variable:
`DATADOG_RUBY_HEADERS_OVERRIDE`.

This way, when building the `datadog` gem, we can point directly at any Ruby source tree and use the headers in it.

**Motivation:**

We have an existing similar mechanism in libdatadog (https://github.com/DataDog/libdatadog/blob/91c0d493f5b62bde6c5f1971e7814f2478b63bf1/ruby/lib/libdatadog.rb#L24) which comes in really handy when we want to quickly test out some change without having to hack the gem or copying over files.

I was using it today to test against latest ruby-head, without having to import those headers explicitly first.

**Additional Notes:**

N/A

**How to test the change?**

This can be easily tested by building the profiler (e.g. `bundle exec rake clean compile`) in the dd-trace-rb repo.

Here's how it looks without this override on Ruby master:

```
**************************************************************************
No source for ruby-3.5.0 (revision a0fe0095ab2711ba54b29cdd2a5957f993cfc1de) provided with
datadog-ruby_core_source gem. Falling back to ruby-3.5.0-preview1.
**************************************************************************
Using datadog-ruby_core_source headers from datadog-ruby_core_source/lib/datadog/ruby_core_source/ruby-3.5.0-preview1
```

and with the override:

```
Using datadog-ruby_core_source headers from .rvm/src/ruby-head
```