### PR TITLE
[PROF-13115] Bump gem version to 3.4.2

### DIFF
--- a/.github/workflows/test-compilation.yml
+++ b/.github/workflows/test-compilation.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - { ruby_version: '4.0', corruption: false, expected_exit_code: 0 } # Used by `dd-trace-rb` for compilation
           - { ruby_version: '3.4', corruption: false, expected_exit_code: 0 } # Used by `dd-trace-rb` for compilation
           - { ruby_version: '3.3', corruption: false, expected_exit_code: 0 } # Used by `dd-trace-rb` for compilation
           - { ruby_version: '3.2', corruption: false, expected_exit_code: 0 }
@@ -21,7 +22,9 @@ jobs:
           - { ruby_version: '2.6', corruption: false, expected_exit_code: 0 }
           - { ruby_version: '2.5', corruption: false, expected_exit_code: 0 } # Used by `dd-trace-rb` for compilation
 
-          # Corruption tests
+          # "Corruption" tests: Validate that missing a file really breaks compilation (and thus our tests are working)
+          # On Rubies that don't use the source, this validates that indeed they aren't using any of these files.
+          - { ruby_version: '4.0', corruption: true,  expected_exit_code: 1 } # Used by `dd-trace-rb` for compilation
           - { ruby_version: '3.4', corruption: true,  expected_exit_code: 1 } # Used by `dd-trace-rb` for compilation
           - { ruby_version: '3.3', corruption: true,  expected_exit_code: 1 } # Used by `dd-trace-rb` for compilation
           - { ruby_version: '3.2', corruption: true,  expected_exit_code: 0 }

--- a/lib/datadog/ruby_core_source/version.rb
+++ b/lib/datadog/ruby_core_source/version.rb
@@ -1,5 +1,5 @@
 module Datadog
   module RubyCoreSource
-    VERSION = '3.4.1'
+    VERSION = '3.4.2'
   end
 end


### PR DESCRIPTION
**What does this PR do?**

This PR bumps the gem version to 3.4.2 in preparation for releasing Ruby 4.0.0-preview2 support (added in #18).

It also updates the `test-compilation.yml` checks to run with Ruby 4.

**Motivation:**

Release a new version with support for 4.0.0-preview2.

**Additional Notes:**

Why version 3.4.2? Adding more headers is backwards-compatible, and while upstream was keeping gem version 1:1 with ruby version, it's awkward to do that with Ruby preview releases so I just bumped the patch :shrug: . We can decide to bump the major once 4.0 stable is out.

**How to test the change?**

The CI check validates this change + I've tested it locally by running `bundle exec rake package`, installing the result, and then confirming the profiler successfully builds with it (tested Ruby 3.4 and 4.0 manually).