### PR TITLE
[PROF-13115] Revert "Temporarily skip broken Ruby 4 test to unblock gem release"

### DIFF
--- a/.github/workflows/test-compilation.yml
+++ b/.github/workflows/test-compilation.yml
@@ -24,15 +24,7 @@ jobs:
 
           # "Corruption" tests: Validate that missing a file really breaks compilation (and thus our tests are working)
           # On Rubies that don't use the source, this validates that indeed they aren't using any of these files.
-          #
-          # TODO: Temporarily disabled so we could release the 4.0.0-beta2 support. Because dd-trace-rb is currently
-          # pinning Ruby 4.0 to a specific hash
-          # (in https://github.com/DataDog/dd-trace-rb/blob/48b4d79d6d043271dc760277ddc820f5343f335c/ruby-4.0.gemfile#L81)
-          # the "corruption" test uses the wrong version of the gem and fails even though everything is fine.
-          # To break the loop, let's omit this test, then we can release this gem, then we can undo the dd-trace-rb
-          # changes, and then we can re-enable the test.
-          #
-          #- { ruby_version: '4.0', corruption: true,  expected_exit_code: 1 } # Used by `dd-trace-rb` for compilation
+          - { ruby_version: '4.0', corruption: true,  expected_exit_code: 1 } # Used by `dd-trace-rb` for compilation
           - { ruby_version: '3.4', corruption: true,  expected_exit_code: 1 } # Used by `dd-trace-rb` for compilation
           - { ruby_version: '3.3', corruption: true,  expected_exit_code: 1 } # Used by `dd-trace-rb` for compilation
           - { ruby_version: '3.2', corruption: true,  expected_exit_code: 0 }


### PR DESCRIPTION
**What does this PR do?**

This reverts commit 551b5ae11310c5bda27205cd3785c04542abe222 from #20.

See #20 for details. In that PR I mentioned:

To break the loop, let's:

1. omit this test temporarily: ✅ done -> this was #20
2. then we can release this gem: ✅ done ->
   https://github.com/DataDog/datadog-ruby_core_source/actions/runs/20059401843, [version 3.4.2 is on rubygems.org](https://rubygems.org/gems/datadog-ruby_core_source/versions/3.4.2)
3. then we can undo the dd-trace-rb pinning: ✅ done ->
   https://github.com/DataDog/dd-trace-rb/pull/5122
4. then we can re-enable the test

This PR is step 4 and gets us back to where we were before the workaround.

**Motivation:**

Remove workaround now that it's not needed anymore!

**Additional Notes:**

N/A

**How to test the change?**

Validate that Ruby 4.0 + "corruption" test is running in CI and green.